### PR TITLE
fix: Allow not to specify -h when -b is set

### DIFF
--- a/src/mainfun.c
+++ b/src/mainfun.c
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    if (!g_ctx.hostname) {
+    if (!g_ctx.payloadpath && !g_ctx.hostname) {
         fprintf(stderr, "%s: option -h is required.\n", argv[0]);
         print_usage(argv[0]);
         return EXIT_FAILURE;


### PR DESCRIPTION
fix #57